### PR TITLE
Cedric: msm8937 lower bcl threshold

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8937.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8937.dtsi
@@ -470,7 +470,7 @@
 			qcom,mitigation-freq-khz = <998400>;
 			qcom,vph-high-threshold-uv = <3500000>;
 			qcom,vph-low-threshold-uv = <3200000>;
-			qcom,soc-low-threshold = <10>;
+			qcom,soc-low-threshold = <5>;
 			qcom,thermal-handle = <&msm_thermal_freq>;
 		};
 	};


### PR DESCRIPTION
Bcl hotplug reduces performance to gain battery life. on msm8937 its broken it doesnt ac t as it should removing it would be dangerous and would cause damage to batteries. Therefore only lower the threshold to 5%.